### PR TITLE
Fix: Pass currentUsername when already logged in

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -468,8 +468,8 @@ const App = memo(() => {
 
         dryRun,
 
-        username,
-        password,
+        username: isLoggedIn ? currentUsername : username,
+        password: isLoggedIn ? undefined : password,
 
         logger,
       });


### PR DESCRIPTION
## Description
Fixes the "Don't know what's my username" error when starting the bot while already logged in.

## Problem
When `isLoggedIn` was true, the app was passing empty `username` and `password` strings to `initInstauto`, causing the bot to fail with an error.

## Solution
Modified `src/App.jsx` line 469 to pass `currentUsername` when already logged in, and `undefined` for password (since it's not needed when using existing cookies).

## Changes
- Pass `currentUsername` instead of empty `username` when `isLoggedIn` is true
- Pass `undefined` for password when already logged in (cookies handle auth)

## Testing
- ✅ Bot successfully starts when already logged in
- ✅ No "Don't know what's my username" error
- ✅ Bot follows users from target accounts as expected

## Note on Login Issues
This PR addresses the username passing bug. The Instagram login selector issues mentioned in #300 require updates to the [instauto](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) dependency (v9.2.1 → v10.0.0 or patching login selectors). I can provide details on the login selector fixes if needed.

Fixes #300